### PR TITLE
Allow recieving sha256 sigs and make IdP SLO/Art urls optional

### DIFF
--- a/lib/Net/SAML2/Binding/POST.pm
+++ b/lib/Net/SAML2/Binding/POST.pm
@@ -43,7 +43,7 @@ sub handle_response {
 
     # unpack and check the signature
     my $xml = decode_base64($response);
-    my $x = Net::SAML2::XML::Sig->new({ x509 => 1 });
+    my $x = Net::SAML2::XML::Sig->new({ x509 => 1, cert => $self->cacert });
     my $ret = $x->verify($xml);
     die "signature check failed" unless $ret;
 

--- a/lib/Net/SAML2/IdP.pm
+++ b/lib/Net/SAML2/IdP.pm
@@ -33,8 +33,8 @@ Constructor
 has 'entityid'       => (isa => Str, is => 'ro', required => 1);
 has 'cacert'         => (isa => Str, is => 'ro', required => 1);
 has 'sso_urls'       => (isa => HashRef[Str], is => 'ro', required => 1);
-has 'slo_urls'       => (isa => HashRef[Str], is => 'ro', required => 1);
-has 'art_urls'       => (isa => HashRef[Str], is => 'ro', required => 1);
+has 'slo_urls'       => (isa => HashRef[Str], is => 'ro');
+has 'art_urls'       => (isa => HashRef[Str], is => 'ro');
 has 'certs'          => (isa => HashRef[Str], is => 'ro', required => 1);
 has 'formats'        => (isa => HashRef[Str], is => 'ro', required => 1);
 has 'default_format' => (isa => Str, is => 'ro', required => 1);
@@ -123,8 +123,8 @@ sub new_from_xml {
     my $self = $class->new(
         entityid       => $xpath->findvalue('//md:EntityDescriptor/@entityID')->value,
         sso_urls       => $data->{SSO},
-        slo_urls       => $data->{SLO},
-        art_urls       => $data->{Art},
+        (defined $data->{SLO} ? (slo_urls => $data->{SLO}) : () ),
+        (defined $data->{Art} ? (art_urls => $data->{Art}) : () ),
         certs          => $data->{Cert},
         formats        => $data->{NameIDFormat},
         default_format => $data->{DefaultFormat},

--- a/lib/Net/SAML2/Role/ProtocolMessage.pm
+++ b/lib/Net/SAML2/Role/ProtocolMessage.pm
@@ -27,7 +27,7 @@ around 'BUILDARGS' => sub {
     my %args = @_;
 
     # random ID for this message
-    $args{id} ||= unpack 'H*', Crypt::OpenSSL::Random::random_pseudo_bytes(16);
+    $args{id} ||='_' . unpack 'H*', Crypt::OpenSSL::Random::random_pseudo_bytes(16);
 
     # IssueInstant in UTC
     my $dt = DateTime->now( time_zone => 'UTC' );


### PR DESCRIPTION
Hi Chris,

It would be great if you could use this in the next release. It allows SLO/Art urls to be optional, as they are not required by the spec. It also allows handling of sha256 signatures in addition to sha1. 

Thank you!
